### PR TITLE
fix: error type assertion with errors.As

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -60,7 +60,9 @@ func Newf(msg string, args ...interface{}) error {
 // Wrapf an error with format string
 func Wrapf(err error, msg string, args ...interface{}) error {
 	wrappedError := errors.Wrapf(err, msg, args...)
-	if customErr, ok := err.(customError); ok {
+
+	var customErr customError
+	if errors.As(err, &customErr) {
 		return customError{
 			code:          customErr.code,
 			originalError: wrappedError,
@@ -77,7 +79,8 @@ func Wrap(err error, msg string) error {
 
 // WithDisplayMessage returns a error containing a display message
 func WithDisplayMessage(err error, msg string) error {
-	if customErr, ok := err.(customError); ok {
+	var customErr customError
+	if errors.As(err, &customErr) {
 		return customError{
 			code:           customErr.code,
 			originalError:  err,
@@ -90,7 +93,8 @@ func WithDisplayMessage(err error, msg string) error {
 
 // Code retrives the error code from an error, defaults to InternalError
 func Code(err error) ErrorCode {
-	if customErr, ok := err.(customError); ok {
+	var customErr customError
+	if errors.As(err, &customErr) {
 		return customErr.code
 	}
 
@@ -100,9 +104,9 @@ func Code(err error) ErrorCode {
 // Cause retrives the original error
 // Note that it will return the error created internally from github.com/pkg/errors
 func Cause(err error) error {
-	custom, ok := err.(customError)
-	if ok {
-		return Cause(errors.Cause(custom.originalError))
+	var customErr customError
+	if errors.As(err, &customErr) {
+		return Cause(errors.Cause(customErr.originalError))
 	}
 
 	return errors.Cause(err)
@@ -110,12 +114,12 @@ func Cause(err error) error {
 
 // DisplayMessage retrives the display message
 func DisplayMessage(err error) string {
-	custom, ok := err.(customError)
-	if ok {
-		if custom.displayMessage != "" {
-			return custom.displayMessage
+	var customErr customError
+	if errors.As(err, &customErr) {
+		if customErr.displayMessage != "" {
+			return customErr.displayMessage
 		}
-		return string(custom.code)
+		return string(customErr.code)
 	}
 
 	return string(InternalError)

--- a/errors_test.go
+++ b/errors_test.go
@@ -139,4 +139,11 @@ var _ = Describe("Errors", func() {
 
 		Expect(fmt.Sprintf("%+v", errors.StackTrace(err))).To(ContainSubstring("/errors_test.go:"))
 	})
+
+	Describe("#Code", func() {
+		It("should return a wrapped error code", func() {
+			err := errors.Join(fmt.Errorf("test"), errors.InvalidArgument.New("invalid argument"))
+			Expect(errors.Code(err)).To(Equal(errors.InvalidArgument))
+		})
+	})
 })


### PR DESCRIPTION
## Linear Ticket Link

N/A

## Description

Currently the errors package uses type assertion to check for a `customErr` which doesn't work with wrapped errors. Replaced the type assertions with `errors.As` usage.

## How did you test the changes?

- Create unit test

## Dependencies

N/A
